### PR TITLE
feat(ui): add APIM key configuration in provider settings

### DIFF
--- a/ui/src/components/ConfigProvider.tsx
+++ b/ui/src/components/ConfigProvider.tsx
@@ -21,6 +21,7 @@ export interface Provider {
   name: string;
   api_base_url: string;
   api_key: string;
+  apim_key?: string;
   models: string[];
   transformer?: ProviderTransformer;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/ui/src/components/Providers.tsx
+++ b/ui/src/components/Providers.tsx
@@ -65,7 +65,7 @@ export function Providers() {
 
 
   const handleAddProvider = () => {
-    const newProviders = [...config.Providers, { name: "", api_base_url: "", api_key: "", models: [] }];
+    const newProviders = [...config.Providers, { name: "", api_base_url: "", api_key: "", apim_key: "", models: [] }];
     setConfig({ ...config, Providers: newProviders });
     setEditingProviderIndex(newProviders.length - 1);
   };
@@ -398,6 +398,10 @@ export function Providers() {
               <div className="space-y-2">
                 <Label htmlFor="api_key">{t("providers.api_key")}</Label>
                 <Input id="api_key" type="password" value={editingProvider.api_key || ''} onChange={(e) => handleProviderChange(editingProviderIndex, 'api_key', e.target.value)} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="apim_key">{t("providers.apim_key")}</Label>
+                <Input id="apim_key" type="password" value={editingProvider.apim_key || ''} onChange={(e) => handleProviderChange(editingProviderIndex, 'apim_key', e.target.value)} />
               </div>
               <div className="space-y-2">
                 <Label htmlFor="models">{t("providers.models")}</Label>

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -49,6 +49,7 @@
     "name": "Name",
     "api_base_url": "API Base URL",
     "api_key": "API Key",
+    "apim_key": "APIM Key",
     "models": "Models",
     "models_placeholder": "Enter model name and press Enter to add",
     "add_model": "Add Model",

--- a/ui/src/locales/zh.json
+++ b/ui/src/locales/zh.json
@@ -49,6 +49,7 @@
     "name": "名称",
     "api_base_url": "API 基础地址",
     "api_key": "API 密钥",
+    "apim_key": "APIM 订阅密钥",
     "models": "模型",
     "models_placeholder": "输入模型名称并按回车键添加",
     "add_model": "添加模型",


### PR DESCRIPTION
## Summary
- allow providers to store APIM key in config
- expose APIM key field in providers settings dialog
- add i18n strings for APIM key

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6890733a60f08327b5b214e8806c7dd8